### PR TITLE
[GH] Fixed LibreQuake listing in credits

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,5 +60,5 @@ All windows builds for this project are currently cross compiled from Linux. The
 ### Credits
 - [Dear ImGui](https://github.com/ocornut/imgui)
 - [YamagiQ2 PakExtract](https://github.com/yquake2/pakextract)
-- [Libre Quake](https://github.com/MissLavender-LQ/LibreQuake)
+- [LibreQuake](https://github.com/lavenderdotpet/LibreQuake)
 - [Kebby-Quake](https://github.com/Kebby-Quake)


### PR DESCRIPTION
removed the space between libre and quake
and updated the link to the current repo username